### PR TITLE
Don't make an ActiveRecord  call in the guard clause checking if the …

### DIFF
--- a/lib/active_set/processors/paginate/active_record_adapter.rb
+++ b/lib/active_set/processors/paginate/active_record_adapter.rb
@@ -15,7 +15,7 @@ class ActiveSet
       private
 
       def paginated_set
-        return @set.none if @set.count <= page_size && page_number > 1
+        return @set.none if @set.length <= page_size && page_number > 1
         @set.limit(page_size).offset(page_offset)
       end
 


### PR DESCRIPTION
…set is smaller than the pagesize and the page requested is greater than 1; use a simple Enumerable  call to avoid an odd low-level AR bug when counting complex queries