### PR TITLE
Avoid a possible error path where relations with a '#union' would blo…

### DIFF
--- a/lib/active_set/processors/sort/active_record_adapter.rb
+++ b/lib/active_set/processors/sort/active_record_adapter.rb
@@ -34,7 +34,7 @@ class ActiveSet
 
       def attribute_model
         @instruction.associations_array
-                    .reduce(@set) do |obj, assoc|
+                    .reduce(@set.klass) do |obj, assoc|
                       obj.reflections[assoc.to_s]&.klass
                     end
       end


### PR DESCRIPTION
…w up when using '#merge' because the '#order' operation was being built with the relation and not with the relation's base class